### PR TITLE
bugfix/use-explicit-resource-counter-id

### DIFF
--- a/src/main/java/uk/nhs/cdss/entities/ResourceId.java
+++ b/src/main/java/uk/nhs/cdss/entities/ResourceId.java
@@ -1,7 +1,6 @@
 package uk.nhs.cdss.entities;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Data;
@@ -10,14 +9,26 @@ import lombok.Data;
 @Entity
 @Table(name = "resource_id")
 public class ResourceId {
-  public static final Long INITIAL_VALUE = 0L;
+
+  /**
+   * A global namespace to apply IDs for any resource type
+   */
+  public static final long GLOBAL = 1;
+  public static final long INITIAL_VALUE = 1;
 
   @Id
-  @GeneratedValue
-  private Long id;
-  private long value;
+  private long id = GLOBAL;
+  private long value = INITIAL_VALUE;
 
   public ResourceId() {
-    this.value = INITIAL_VALUE;
+  }
+
+  public ResourceId(long id) {
+    this(id, INITIAL_VALUE);
+  }
+
+  public ResourceId(long id, long value) {
+    this.id = id;
+    this.value = value;
   }
 }

--- a/src/main/java/uk/nhs/cdss/entities/ResourceId.java
+++ b/src/main/java/uk/nhs/cdss/entities/ResourceId.java
@@ -4,9 +4,11 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Entity
+@NoArgsConstructor
 @Table(name = "resource_id")
 public class ResourceId {
 
@@ -19,9 +21,6 @@ public class ResourceId {
   @Id
   private long id = GLOBAL;
   private long value = INITIAL_VALUE;
-
-  public ResourceId() {
-  }
 
   public ResourceId(long id) {
     this(id, INITIAL_VALUE);

--- a/src/main/java/uk/nhs/cdss/entities/ResourceIndex.java
+++ b/src/main/java/uk/nhs/cdss/entities/ResourceIndex.java
@@ -10,11 +10,13 @@ import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.hl7.fhir.dstu3.model.ResourceType;
 
 @Entity
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @Table(name = "resource_index", indexes = {
     @Index(columnList = "supplierId,resource_type,path,value")

--- a/src/main/java/uk/nhs/cdss/service/ResourceIdService.java
+++ b/src/main/java/uk/nhs/cdss/service/ResourceIdService.java
@@ -13,11 +13,11 @@ public class ResourceIdService {
   private final ResourceIdRepository resourceIdRepository;
 
   public Long nextId() {
-    if (!resourceIdRepository.existsById(1L)) {
-      resourceIdRepository.save(new ResourceId());
-      return ResourceId.INITIAL_VALUE;
+    if (!resourceIdRepository.existsById(ResourceId.GLOBAL)) {
+      ResourceId id = resourceIdRepository.save(new ResourceId(ResourceId.GLOBAL));
+      return id.getValue();
     }
 
-    return resourceIdRepository.incrementAndGet(1L);
+    return resourceIdRepository.incrementAndGet(ResourceId.GLOBAL);
   }
 }

--- a/src/test/java/uk/nhs/cdss/resourceProviders/CarePlanProviderComponentTest.java
+++ b/src/test/java/uk/nhs/cdss/resourceProviders/CarePlanProviderComponentTest.java
@@ -3,7 +3,6 @@ package uk.nhs.cdss.resourceProviders;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.Collection;
@@ -11,6 +10,7 @@ import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
 import org.hl7.fhir.dstu3.model.CarePlan;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.nhs.cdss.SecurityUtil;
 import uk.nhs.cdss.fixtures.CarePlanFixtures;
 import uk.nhs.cdss.service.ResourceService;
 
@@ -26,6 +27,8 @@ import uk.nhs.cdss.service.ResourceService;
 @RunWith(SpringRunner.class)
 @TestPropertySource(locations = "classpath:application-test.properties")
 public class CarePlanProviderComponentTest {
+
+  private static final String SUPPLIER = "supplier";
 
   @Autowired
   private CarePlanProvider carePlanProvider;
@@ -35,6 +38,11 @@ public class CarePlanProviderComponentTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    SecurityUtil.setCurrentSupplier(SUPPLIER);
+  }
 
   @Test
   public void findsCarePlan() {

--- a/src/test/java/uk/nhs/cdss/resourceProviders/EncounterProviderComponentTest.java
+++ b/src/test/java/uk/nhs/cdss/resourceProviders/EncounterProviderComponentTest.java
@@ -10,6 +10,7 @@ import org.hamcrest.Matcher;
 import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.nhs.cdss.SecurityUtil;
 import uk.nhs.cdss.entities.ResourceEntity;
 import uk.nhs.cdss.fixtures.EncounterFixtures;
 import uk.nhs.cdss.fixtures.PatientFixtures;
@@ -31,6 +33,8 @@ import uk.nhs.cdss.service.ResourceService;
 )
 public class EncounterProviderComponentTest {
 
+  private static final String SUPPLIER = "supplier";
+
   @Autowired
   private EncounterProvider encounterProvider;
 
@@ -39,6 +43,11 @@ public class EncounterProviderComponentTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    SecurityUtil.setCurrentSupplier(SUPPLIER);
+  }
 
   @Test
   public void findsEncounter() {

--- a/src/test/java/uk/nhs/cdss/service/ResourceIdServiceTest.java
+++ b/src/test/java/uk/nhs/cdss/service/ResourceIdServiceTest.java
@@ -28,7 +28,11 @@ public class ResourceIdServiceTest {
 
   @Test
   public void createsNewId() {
-    when(idRepository.existsById(1L)).thenReturn(false);
+
+    when(idRepository.existsById(ResourceId.GLOBAL)).thenReturn(false);
+
+    ResourceId expectedInitialId = new ResourceId(ResourceId.GLOBAL);
+    when(idRepository.save(expectedInitialId)).thenReturn(expectedInitialId);
 
     Long returnedId = resourceIdService.nextId();
 


### PR DESCRIPTION
When checking if the resourceId record exists, force the ID to a known value rather than relying on the autonumbering to be correct.